### PR TITLE
show results in the order of date

### DIFF
--- a/memo.c
+++ b/memo.c
@@ -2488,14 +2488,14 @@ static void sort_dates_ascend(char *dates[], int date_index)
 {
   int dates_int[date_index];
 
-	/* Remove "-" from the dates elements and convert them into integer. */
+  /* Remove "-" from the dates elements and convert them into integer. */
   for (int i = 0; i < date_index; i++) {
 		char *p = dates[i], *q = dates[i];
 		while((*p = *q++)) p += (*p != '-');
 		dates_int[i] = atoi(dates[i]);
   }
 
-	/* Sort the dates_int elements in ascending order. */
+  /* Sort the dates_int elements in ascending order. */
   qsort((void *)dates_int , date_index , sizeof(dates_int[0]), int_sort);
 
   /* For each of dates_int elements, 

--- a/memo.c
+++ b/memo.c
@@ -2503,22 +2503,22 @@ static void sort_dates_ascend(char *dates[], int date_index)
    */
   for (int i = 0; i < date_index; i++) {
 		memset(dates[i], '\0', sizeof(*dates));
-
-  	/* Pick up the 4-digit year from dates_int[i]. */
-  	strcat(dates[i], integer_to_string(dates_int[i]/10000000));
-  	strcat(dates[i], integer_to_string((dates_int[i]/1000000) % 10));
-  	strcat(dates[i], integer_to_string((dates_int[i]/100000) % 10));
-  	strcat(dates[i], integer_to_string((dates_int[i]/10000) % 10));
-  	strcat(dates[i], "-");
-
-  	/* Pick up the 2-digit month from dates_int[i]. */
-  	strcat(dates[i], integer_to_string((dates_int[i]/1000) % 10));
-  	strcat(dates[i], integer_to_string((dates_int[i]/100) % 10));
-  	strcat(dates[i], "-");
-
-  	/* Pick up the 2-digit day from dates_int[i]. */
-  	strcat(dates[i], integer_to_string((dates_int[i]/10) % 10));
-  	strcat(dates[i], integer_to_string(dates_int[i] % 10));
+		
+		/* Pick up the 4-digit year from dates_int[i]. */
+		strcat(dates[i], integer_to_string(dates_int[i]/10000000));
+		strcat(dates[i], integer_to_string((dates_int[i]/1000000) % 10));
+		strcat(dates[i], integer_to_string((dates_int[i]/100000) % 10));
+		strcat(dates[i], integer_to_string((dates_int[i]/10000) % 10));
+		strcat(dates[i], "-");
+		
+		/* Pick up the 2-digit month from dates_int[i]. */
+		strcat(dates[i], integer_to_string((dates_int[i]/1000) % 10));
+		strcat(dates[i], integer_to_string((dates_int[i]/100) % 10));
+		strcat(dates[i], "-");
+		
+		/* Pick up the 2-digit day from dates_int[i]. */
+		strcat(dates[i], integer_to_string((dates_int[i]/10) % 10));
+		strcat(dates[i], integer_to_string(dates_int[i] % 10));
   }
 }
 

--- a/memo.c
+++ b/memo.c
@@ -2492,7 +2492,7 @@ static void sort_dates_ascend(char *dates[], int date_index)
   for (int i = 0; i < date_index; i++) {
 		char *p = dates[i], *q = dates[i];
 		while((*p = *q++)) p += (*p != '-');
-  	dates_int[i] = atoi(dates[i]);
+		dates_int[i] = atoi(dates[i]);
   }
 
 	/* Sort the dates_int elements in ascending order. */


### PR DESCRIPTION
# memo

Currently -o option shows results in the order of id as follows. 

	2015-02-02
	        2       U       test
	        7       U       テスト
	2014-03-02
	        3       U       test
	        6       U       test
	1001-02-22
	        5       U       test

This PR can show results in the order of date as follows.

	1001-02-22
	        5       U       test
	2014-03-02
	        3       U       test
	        6       U       test
	2015-02-02
	        2       U       test
	        7       U       テスト
