### PR TITLE
Makefile tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS+=-std=c99 -Wall
-PREFIX=/usr/local
+PREFIX?=/usr/local
 
 ifeq ($(OS),Windows_NT)
 LDFLAGS+=-lpcre

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-CFLAGS+=-std=c99 -Wall
 PREFIX?=/usr/local
+MANPREFIX?=$(PREFIX)/man
+
+CFLAGS+=-std=c99 -Wall
 
 ifeq ($(OS),Windows_NT)
 LDFLAGS+=-lpcre
@@ -11,11 +13,11 @@ clean:
 	rm -f memo *.o
 
 install: all
-	install -d $(PREFIX)/bin $(PREFIX)/share/man/man1
+	install -d $(PREFIX)/bin $(MANPREFIX)/man1
 	install -m755 memo $(PREFIX)/bin/
-	install -m644 memo.1 $(PREFIX)/share/man/man1/
+	install -m644 memo.1 $(MANPREFIX)/man1/
 
 uninstall:
 	rm -f $(PREFIX)/bin/memo
-	rm -f $(PREFIX)/share/man/man1/memo.1
+	rm -f $(MANPREFIX)/man1/memo.1
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,6 @@ install: all
 	install -m644 memo.1 $(PREFIX)/share/man/man1/
 
 uninstall:
-	rm $(PREFIX)/bin/memo
-	rm $(PREFIX)/share/man/man1/memo.1
+	rm -f $(PREFIX)/bin/memo
+	rm -f $(PREFIX)/share/man/man1/memo.1
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-CC=gcc
 override CFLAGS+=-std=c99 -Wall
 PREFIX=/usr/local
 LDFLAGS=

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+DESTDIR?=
 PREFIX?=/usr/local
 MANPREFIX?=$(PREFIX)/man
 
@@ -13,11 +14,11 @@ clean:
 	rm -f memo *.o
 
 install: all
-	install -d $(PREFIX)/bin $(MANPREFIX)/man1
-	install -m755 memo $(PREFIX)/bin/
-	install -m644 memo.1 $(MANPREFIX)/man1/
+	install -d $(DESTDIR)$(PREFIX)/bin $(DESTDIR)$(MANPREFIX)/man1
+	install -m755 memo $(DESTDIR)$(PREFIX)/bin/
+	install -m644 memo.1 $(DESTDIR)$(MANPREFIX)/man1/
 
 uninstall:
-	rm -f $(PREFIX)/bin/memo
-	rm -f $(MANPREFIX)/man1/memo.1
+	rm -f $(DESTDIR)$(PREFIX)/bin/memo
+	rm -f $(DESTDIR)$(MANPREFIX)/man1/memo.1
 

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,9 @@ install: all
 		mkdir -p $(PREFIX)/share/man/man1;	\
 	fi
 	cp memo.1 $(PREFIX)/share/man/man1/
-	gzip -f $(PREFIX)/share/man/man1/memo.1
 	cp memo $(PREFIX)/bin/
 
 uninstall:
 	rm $(PREFIX)/bin/memo
-	rm $(PREFIX)/share/man/man1/memo.1.gz
+	rm $(PREFIX)/share/man/man1/memo.1
 

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,6 @@ endif
 
 all: memo
 
-memo: memo.o
-	$(CC) $(CFLAGS) memo.o -o memo $(LDFLAGS)
-
-memo.o: memo.c
-	$(CC) $(CFLAGS) -c memo.c
-
 clean:
 	rm -f memo *.o
 

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,9 @@ clean:
 	rm *.o
 
 install: all
-	if [ ! -d $(PREFIX)/share/man/man1 ];then	\
-		mkdir -p $(PREFIX)/share/man/man1;	\
-	fi
-	cp memo.1 $(PREFIX)/share/man/man1/
-	cp memo $(PREFIX)/bin/
+	install -d $(PREFIX)/bin $(PREFIX)/share/man/man1
+	install -m755 memo $(PREFIX)/bin/
+	install -m644 memo.1 $(PREFIX)/share/man/man1/
 
 uninstall:
 	rm $(PREFIX)/bin/memo

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,7 @@ memo.o: memo.c
 	$(CC) $(CFLAGS) -c memo.c
 
 clean:
-	rm memo
-	rm *.o
+	rm -f memo *.o
 
 install: all
 	install -d $(PREFIX)/bin $(PREFIX)/share/man/man1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-override CFLAGS+=-std=c99 -Wall
+CFLAGS+=-std=c99 -Wall
 PREFIX=/usr/local
 LDFLAGS=
 

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,4 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/memo
 	rm -f $(DESTDIR)$(MANPREFIX)/man1/memo.1
 
+.PHONY: all clean install uninstall

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-DESTDIR?=
-PREFIX?=/usr/local
-MANPREFIX?=$(PREFIX)/man
+DESTDIR   ?=
+PREFIX    ?= /usr/local
+MANPREFIX ?= $(PREFIX)/man
 
-CFLAGS+=-std=c99 -Wall
+CFLAGS += -std=c99 -Wall
 
 ifeq ($(OS),Windows_NT)
-LDFLAGS+=-lpcre
+  LDFLAGS += -lpcre
 endif
 
 all: memo

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 CFLAGS+=-std=c99 -Wall
 PREFIX=/usr/local
-LDFLAGS=
 
 ifeq ($(OS),Windows_NT)
-LDFLAGS=-lpcre
+LDFLAGS+=-lpcre
 endif
 
 all: memo


### PR DESCRIPTION
 - Don't gzip man page
 - Use install instead of mkdir and cp
 - Use rm -f in uninstall
 - Don't hardcode compiler
 - Respect overridden CFLAGS
 - Respect environment LDFLAGS
 - Use rm -f in clean
 - Remove compilation and link rules
 - Default to environment PREFIX
 - Add MANPREFIX variable
 - Add DESTDIR variable
 - Mark .PHONY targets

Mostly to make packaging easier - I particularly care about DESTDIR, MANPREFIX, gzipped man pages and CC - but many of these are a matter of taste so feel free to cherry pick as you feel appropriate.